### PR TITLE
Account, Orders(users), Admin Users (frontend)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,8 @@ import ProtectedRoute from './components/ProtectedRoute.jsx';
 import { Toaster } from 'react-hot-toast';
 import Cart from './pages/Cart.jsx';
 import MyOrders from './pages/MyOrders.jsx';
-
+import AdminUsers from './pages/AdminUsers.jsx';
+import Account from './pages/Account.jsx';
 
 export default function App() {
   return (
@@ -46,6 +47,7 @@ export default function App() {
             <Route path="/cart" element={<Cart />} />
             <Route path="/orders/my" element={<ProtectedRoute><MyOrders /></ProtectedRoute>} />
             <Route path="/admin/users" element={<ProtectedRoute role="admin"><AdminUsers /></ProtectedRoute>} />
+            <Route path="/account" element={<ProtectedRoute><Account /></ProtectedRoute>} />
           </Routes>
         </div>
       </main>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,7 @@ export default function App() {
             />
             <Route path="/cart" element={<Cart />} />
             <Route path="/orders/my" element={<ProtectedRoute><MyOrders /></ProtectedRoute>} />
+            <Route path="/admin/users" element={<ProtectedRoute role="admin"><AdminUsers /></ProtectedRoute>} />
           </Routes>
         </div>
       </main>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,8 @@ import CheckoutCancel from './pages/CheckoutCancel.jsx';
 import ProtectedRoute from './components/ProtectedRoute.jsx';
 import { Toaster } from 'react-hot-toast';
 import Cart from './pages/Cart.jsx';
+import MyOrders from './pages/MyOrders.jsx';
+
 
 export default function App() {
   return (
@@ -42,6 +44,7 @@ export default function App() {
               }
             />
             <Route path="/cart" element={<Cart />} />
+            <Route path="/orders/my" element={<ProtectedRoute><MyOrders /></ProtectedRoute>} />
           </Routes>
         </div>
       </main>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -34,6 +34,14 @@ export default function Navbar() {
             <Link to="/admin" className={navLink}>Admin</Link>
           )}
 
+          {/* Just added, needs test: Show Orders (user history) and Account when logged in */}
+          {token && (
+          <>
+            <Link to="/orders/my" className={navLink}>Orders</Link>
+            <Link to="/account" className={navLink}>Account</Link>
+          </>
+          )}
+
           {/* Auth area */}
           {token ? (
             <span

--- a/frontend/src/pages/Account.jsx
+++ b/frontend/src/pages/Account.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { api } from '../lib/api.js';
+import { toastError, toastSuccess } from '../lib/toast.js';
+import { useAuth } from '../context/AuthContext.jsx';
+import { useNavigate } from 'react-router-dom';
+
+export default function Account() {
+  const { user, logout } = useAuth();
+  const nav = useNavigate();
+
+  const del = async () => {
+    if (!confirm('This will permanently delete your account. Continue?')) return;
+    try {
+      await api.delete('/auth/me');
+      toastSuccess('Account deleted');
+      logout();
+      nav('/');
+    } catch {
+      toastError('Failed to delete account');
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto bg-white rounded-xl border p-6">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-4">My Account</h1>
+      {user ? (
+        <>
+          <div className="space-y-1 text-gray-800">
+            <p><span className="font-medium">Email:</span> {user.email}</p>
+            <p><span className="font-medium">Name:</span> {user.name}</p>
+            <p><span className="font-medium">Role:</span> {user.role}</p>
+          </div>
+
+          <div className="mt-6">
+            <button
+              className="px-3 py-2 rounded-lg text-sm font-medium border border-gray-400 text-gray-900 bg-white hover:bg-gray-200 transition"
+              onClick={del}
+            >
+              Delete my account
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="text-gray-600">You’re not logged in.</p>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../lib/api.js';
+import { toastError, toastSuccess } from '../lib/toast.js';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function AdminUsers() {
+  const { user } = useAuth();
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState('');
+
+  const load = async () => {
+    setLoading(true); setErr('');
+    try {
+      const { data } = await api.get('/users');
+      setRows(data || []);
+    } catch {
+      setErr('Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const changeRole = async (id, role) => {
+    try {
+      const { data } = await api.patch(`/users/${id}/role`, { role });
+      setRows((r) => r.map(u => u._id === id ? data : u));
+      toastSuccess(`Role updated to ${role}`);
+    } catch {
+      toastError('Failed to update role');
+    }
+  };
+
+  const delUser = async (id) => {
+    if (id === user?._id) {
+      toastError('You cannot delete your own admin account here.');
+      return;
+    }
+    if (!confirm('Delete this user?')) return;
+    try {
+      await api.delete(`/users/${id}`);
+      setRows((r) => r.filter(u => u._id !== id));
+      toastSuccess('User deleted');
+    } catch {
+      toastError('Failed to delete user');
+    }
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">Manage Users</h1>
+
+      {loading && <div className="py-16 text-center text-gray-500">Loading users…</div>}
+      {err && <div className="py-4 text-center text-red-600">{err}</div>}
+
+      {!loading && !err && (
+        <div className="overflow-x-auto bg-white rounded-xl border">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="text-left p-3 font-semibold text-gray-700">Email</th>
+                <th className="text-left p-3 font-semibold text-gray-700">Name</th>
+                <th className="text-left p-3 font-semibold text-gray-700">Role</th>
+                <th className="text-left p-3 font-semibold text-gray-700">Created</th>
+                <th className="text-right p-3 font-semibold text-gray-700">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((u) => (
+                <tr key={u._id} className="border-t">
+                  <td className="p-3">{u.email}</td>
+                  <td className="p-3">{u.name}</td>
+                  <td className="p-3">
+                    <select
+                      className="border rounded px-2 py-1 text-gray-900 bg-white"
+                      value={u.role}
+                      onChange={(e) => changeRole(u._id, e.target.value)}
+                    >
+                      <option value="user">user</option>
+                      <option value="admin">admin</option>
+                    </select>
+                  </td>
+                  <td className="p-3">{new Date(u.createdAt).toLocaleDateString()}</td>
+                  <td className="p-3 text-right">
+                    <button
+                      className="px-3 py-2 rounded-lg text-sm font-medium border border-gray-400 text-gray-900 bg-white hover:bg-gray-200 transition"
+                      onClick={() => delUser(u._id)}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {!rows.length && (
+                <tr><td className="p-6 text-center text-gray-500" colSpan={5}>No users</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+

--- a/frontend/src/pages/MyOrders.jsx
+++ b/frontend/src/pages/MyOrders.jsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+import { api } from '../lib/api.js';
+
+const fmt = (cents) =>
+  (Number(cents) / 100).toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+
+export default function MyOrders() {
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const { data } = await api.get('/orders/my');
+        if (alive) setOrders(data || []);
+      } catch (e) {
+        if (alive) setErr('Failed to load orders');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  if (loading) return <div className="py-16 text-center text-gray-500">Loading orders…</div>;
+  if (err) return <div className="py-16 text-center text-red-600">{err}</div>;
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">My Orders</h1>
+
+      {!orders.length ? (
+        <div className="py-16 text-center text-gray-500">You don’t have any purchases yet.</div>
+      ) : (
+        <ul className="space-y-4">
+          {orders.map((o) => (
+            <li key={o._id} className="bg-white rounded-xl border p-4">
+              <div className="flex items-center justify-between">
+                <div className="text-sm text-gray-600">
+                  <span className="font-medium text-gray-900">Order:</span> {o._id.slice(-8)}
+                  <span className="mx-2">•</span>
+                  {new Date(o.createdAt).toLocaleString()}
+                </div>
+                <div className="text-gray-900 font-semibold">{fmt(o.total)}</div>
+              </div>
+
+              <ul className="mt-3 grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+                {(o.items || []).map((it, idx) => (
+                  <li key={idx} className="rounded-lg border overflow-hidden">
+                    <div className="aspect-[4/3] bg-gray-100">
+                      <img
+                        src={it.imageUrl}
+                        alt={it.title || 'Wallpaper'}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                      />
+                    </div>
+                    <div className="p-3">
+                      <p className="font-medium text-gray-900">{it.title}</p>
+                      <p className="text-sm text-gray-600">{fmt(it.price)}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+


### PR DESCRIPTION
Add user-facing Account + Orders pages and an Admin Users page.

My Orders:
- New page `/orders/my` (protected) showing past purchases from GET /api/orders/my

Admin Users:
- New page `/admin/users` (admin-only) to list users, change role, and delete users

Account:
- New page `/account` (protected) with “Delete my account” (DELETE /api/auth/me)

Navbar:
- Show Orders and Account links when logged-in
