### PR TITLE
Cancel Page Polish

### DIFF
--- a/frontend/src/pages/CheckoutCancel.jsx
+++ b/frontend/src/pages/CheckoutCancel.jsx
@@ -1,6 +1,35 @@
+// frontend/src/pages/CheckoutCancel.jsx
 import React from 'react';
-export default function CheckoutCancel(){
-  return <p className="text-gray-600">Payment canceled. You can continue browsing.</p>;
+import { Link, useSearchParams } from 'react-router-dom';
+
+export default function CheckoutCancel() {
+  const [params] = useSearchParams();
+  const reason = params.get('reason'); // optional ?reason=...
+  const note = reason ? `Reason: ${reason}` : 'You can try again anytime.';
+
+  return (
+    <div className="max-w-xl mx-auto bg-white rounded-xl border p-6 text-center">
+      <h1 className="text-2xl font-semibold text-gray-900">Payment canceled</h1>
+      <p className="mt-2 text-gray-700">
+        Your checkout was canceled before completion. {note}
+      </p>
+
+      <div className="mt-6 flex gap-2 justify-center">
+        <Link
+          to="/cart"
+          className="px-3 py-2 rounded-lg text-sm font-medium border border-blue-600 text-blue-600 bg-white hover:bg-blue-50 transition"
+        >
+          Return to cart
+        </Link>
+        <Link
+          to="/"
+          className="px-3 py-2 rounded-lg text-sm font-medium border border-blue-600 text-blue-600 bg-white hover:bg-blue-50 transition"
+        >
+          Continue shopping
+        </Link>
+      </div>
+    </div>
+  );
 }
 
 


### PR DESCRIPTION
Payments cancel: polish cancel page with Return to Cart/Continue Shopping:
- Add styled CheckoutCancel page with clear messaging
- Outlined-blue actions: Return to cart / Continue shopping
- Matches app-wide button style

