### PR TITLE
Fix frontend use VITE_API_BASE_URL for API base instead of localhost fallback.

### DIFF
--- a/frontend/src/lib/apiBase.js
+++ b/frontend/src/lib/apiBase.js
@@ -1,5 +1,5 @@
 // frontend/src/lib/apiBase.js
-export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+export const API_BASE =
+  import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:5000';
 
-
-
+export default API_BASE;


### PR DESCRIPTION
Fix frontend use VITE_API_BASE_URL for API base instead of localhost fallback.