### PR TITLE
fix(api): add Admin Users endpoint at /api/admin/users

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,8 @@ import productRoutes from './routes/products.js';
 import checkoutRoutes from './routes/checkout.js';
 import ordersRoutes from './routes/orders.js';
 import usersRoutes from './routes/users.js';
+import adminUsersRoutes from './routes/adminUsers.js';
+
 
 // --- Validate required envs ---
 required([
@@ -66,6 +68,9 @@ app.use('/api/products', productRoutes);
 app.use('/api/checkout', checkoutRoutes);
 app.use('/api/orders', ordersRoutes);
 app.use('/api/users', usersRoutes);
+app.use('/api/admin/users', adminUsersRoutes);
+
+
 
 // --- Start server ---
 const PORT = process.env.PORT || 5000;

--- a/backend/src/routes/adminUsers.js
+++ b/backend/src/routes/adminUsers.js
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const router = Router();
+
+// If you already have requireAuth/requireAdmin middleware, import those and delete these:
+function requireAuth(req, res, next) {
+  const header = req.headers.authorization || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+  try { req.user = jwt.verify(token, process.env.JWT_SECRET); next(); }
+  catch { return res.status(401).json({ error: 'Unauthorized' }); }
+}
+function requireAdmin(req, res, next) {
+  if (req.user?.role !== 'admin') return res.status(403).json({ error: 'Forbidden' });
+  next();
+}
+
+// GET /api/admin/users?limit=1000
+router.get('/', requireAuth, requireAdmin, async (req, res) => {
+  const limit = Math.min(parseInt(req.query.limit || '100', 10), 1000);
+  const users = await User.find()
+    .select('-password -passwordHash -__v')
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+  res.json(users);
+});
+
+export default router;


### PR DESCRIPTION
Admin → Users returned 404 in production. The frontend requests /api/admin/users?limit=1000,
but the API did not expose that route.

- Add admin-only users listing route.
- Guard with JWT auth + admin role.
- Redact sensitive fields and cap limit.
- Mount at /api/admin/users (no aliases to avoid conflict with /api/users profile endpoints).

Updated:
- backend/src/routes/adminUsers.js  (new)
- backend/src/index.js             (mount route)

Deployment
- Merge to main; Render API redeploys. No env changes required.

Risk
Low: read-only endpoint; no changes to existing /api/users.
